### PR TITLE
Integrate rotary positional encodings

### DIFF
--- a/protein_lm/modeling/models/apt/model_pytorch.py
+++ b/protein_lm/modeling/models/apt/model_pytorch.py
@@ -22,7 +22,7 @@ from transformers.utils import logging
 from transformers.utils.model_parallel_utils import assert_device_map, get_device_map
 from .outputs import APTCausalLMOutputWithCrossAttentions
 from .activations import APT_ACT2FN
-from ...rotary_embedding import RotaryEmbedding
+from ...utils.rotary_embedding import RotaryEmbedding
 
 
 logger = logging.get_logger(__name__)

--- a/protein_lm/modeling/models/apt/model_pytorch.py
+++ b/protein_lm/modeling/models/apt/model_pytorch.py
@@ -93,7 +93,7 @@ class APTAttention(nn.Module):
 
     def _attn(self, query, key, value, attention_mask=None, head_mask=None):
 
-        # apply rotary embeddings to 
+        # Apply rotary embeddings to query and key
         if self.rot_emb:
             query, key = self.rot_emb(query,key)
 

--- a/protein_lm/modeling/models/apt/model_pytorch.py
+++ b/protein_lm/modeling/models/apt/model_pytorch.py
@@ -240,8 +240,6 @@ class APTAttention(nn.Module):
             present = (key, value)
         else:
             present = None
-            
-
 
         if self.reorder_and_upcast_attn:
             attn_output, attn_weights = self._upcast_and_reordered_attn(query, key, value, attention_mask, head_mask)

--- a/protein_lm/modeling/models/apt/model_pytorch.py
+++ b/protein_lm/modeling/models/apt/model_pytorch.py
@@ -93,7 +93,7 @@ class APTAttention(nn.Module):
 
     def _attn(self, query, key, value, attention_mask=None, head_mask=None):
 
-        # Apply rotary embeddings to query and key
+        # Apply rotary embedding to query and key
         if self.rot_emb:
             query, key = self.rot_emb(query,key)
 
@@ -141,7 +141,7 @@ class APTAttention(nn.Module):
         bsz, num_heads, q_seq_len, dk = query.size()
         _, _, k_seq_len, _ = key.size()
 
-        # Apply rotary embedding to query, key
+        # Apply rotary embedding to query and key
         if self.rot_emb:
             query, key = self.rot_emb(query,key)
 

--- a/protein_lm/modeling/models/apt/model_pytorch.py
+++ b/protein_lm/modeling/models/apt/model_pytorch.py
@@ -22,6 +22,7 @@ from transformers.utils import logging
 from transformers.utils.model_parallel_utils import assert_device_map, get_device_map
 from .outputs import APTCausalLMOutputWithCrossAttentions
 from .activations import APT_ACT2FN
+from ...rotary_embedding import RotaryEmbedding
 
 
 logger = logging.get_logger(__name__)
@@ -73,7 +74,7 @@ class APTAttention(nn.Module):
 
         self.rot_emb=None
         if config.position_embedding == "rotary":
-            self.rot_emb=RotaryEmbeddin(dim=self.head_dim)
+            self.rot_emb=RotaryEmbedding(dim=self.head_dim)
 
     def prune_heads(self, heads):
         if len(heads) == 0:

--- a/protein_lm/modeling/utils/rotary_embedding.py
+++ b/protein_lm/modeling/utils/rotary_embedding.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+
+
+def rotate_half(x):
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(x, cos, sin):
+    cos = cos[:, : x.shape[-2], :]
+    sin = sin[:, : x.shape[-2], :]
+
+    return (x * cos) + (rotate_half(x) * sin)
+
+
+class RotaryEmbedding(torch.nn.Module):
+    """
+    The rotary position embeddings from RoFormer_ (Su et. al).
+    A crucial insight from the method is that the query and keys are
+    transformed by rotation matrices which depend on the relative positions.
+    Other implementations are available in the Rotary Transformer repo_ and in
+    GPT-NeoX_, GPT-NeoX was an inspiration
+    .. _RoFormer: https://arxiv.org/abs/2104.09864
+    .. _repo: https://github.com/ZhuiyiTechnology/roformer
+    .. _GPT-NeoX: https://github.com/EleutherAI/gpt-neox
+    .. warning: Please note that this embedding is not registered on purpose, as it is transformative
+        (it does not create the embedding dimension) and will likely be picked up (imported) on a ad-hoc basis
+    """
+
+    def __init__(self, dim: int, *_, **__):
+        super().__init__()
+        # Generate and save the inverse frequency buffer (non trainable)
+        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq)
+
+        self._seq_len_cached = None
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def _update_cos_sin_tables(self, x, seq_dimension=1):
+        seq_len = x.shape[seq_dimension]
+
+        # Reset the tables if the sequence length has changed,
+        # or if we're on a new device (possibly due to tracing for instance)
+        if seq_len != self._seq_len_cached or self._cos_cached.device != x.device:
+            self._seq_len_cached = seq_len
+            t = torch.arange(x.shape[seq_dimension], device=x.device).type_as(self.inv_freq)
+            freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+
+            self._cos_cached = emb.cos()[None, :, :]
+            self._sin_cached = emb.sin()[None, :, :]
+
+        return self._cos_cached, self._sin_cached
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        self._cos_cached, self._sin_cached = self._update_cos_sin_tables(k, seq_dimension=-2)
+
+        return (
+            apply_rotary_pos_emb(q, self._cos_cached, self._sin_cached),
+            apply_rotary_pos_emb(k, self._cos_cached, self._sin_cached),
+        )


### PR DESCRIPTION
This PR integrates rotary positional encodings into the APT model per issue #21 
1. Created a new dir "utils" under "modeling" with a "init.py" and "rotary_embedding.py" file (used [this](https://github.com/facebookresearch/esm/blob/main/esm/rotary_embedding.py) file for instantiation)
2.  Adapted the APT model class to support rotary embeddings in the attention functions.
3. Verified that code runs by setting `position_embedding = "rotary"` in the [config.py file](https://github.com/OpenBioML/protein-lm-scaling/blob/main/protein_lm/modeling/models/apt/config.py#L18) and ran the train.py script.

I will keep the default positional_embeddings to "grouped_alibi"