### PR TITLE
fix: allow max_steps training arg to be negative

### DIFF
--- a/protein_lm/modeling/getters/training_args.py
+++ b/protein_lm/modeling/getters/training_args.py
@@ -21,7 +21,6 @@ class TrainingArgsConfig(BaseModel):
     @field_validator(
         "per_device_train_batch_size",
         "num_train_epochs",
-        "max_steps",
         "weight_decay",
         "learning_rate",
         "save_steps",


### PR DESCRIPTION
Addresses #36 .

In order for `num_train_epochs` to actually affect the number of training epochs, `max_steps` has to be set to `-1` which currently cannot be done because of the pydantic validator, which came from a refactor of the constraint in:
https://github.com/OpenBioML/protein-lm-scaling/blob/2d59901e434a12b9e0a142ef223165c44812c7af/protein_lm/modeling/scripts/train.py#L97
https://github.com/OpenBioML/protein-lm-scaling/blob/2d59901e434a12b9e0a142ef223165c44812c7af/protein_lm/modeling/scripts/train.py#L132

This PR removes the greater than zero validator for `max_steps`, allowing it to be set to `-1`, which is required for `num_train_epochs` to have an effect.